### PR TITLE
Ignore OSError during build and installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ def cleanup():
     if "develop" not in sys.argv:
         try:
             shutil.rmtree('abipy.egg-info')
-        except IOError:
+        except (IOError, OSError):
             try:
                 os.unlink('abipy.egg-info')
             except:


### PR DESCRIPTION
When I try to install the package from source, I'm seeing:
```
Traceback (most recent call last):
  File "setup.py", line 272, in <module>
    cleanup()
  File "setup.py", line 161, in cleanup
    shutil.rmtree('abipy.egg-info')
  File "/Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/python-2.7.13-hcpozzgaht7gddrvyrn2fprcm5tmqqii/lib/python2.7/shutil.py", line 239, in rmtree
    onerror(os.listdir, path, sys.exc_info())
  File "/Users/Adam/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/python-2.7.13-hcpozzgaht7gddrvyrn2fprcm5tmqqii/lib/python2.7/shutil.py", line 237, in rmtree
    names = os.listdir(path)
OSError: [Errno 2] No such file or directory: 'abipy.egg-info'
```
This patch properly handles the `OSError` and allows me to build abipy successfully.

This patch is incorporated in [Spack's abipy package](https://github.com/LLNL/spack/pull/3352), so when this is merged, it can be removed from Spack as well.